### PR TITLE
fix(Vue): rerender Vue by reusing existing app

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -115,7 +115,7 @@ export async function render(
     }
     case "Vue": {
       const Vue = await require("vue");
-      const app = storyResult.app;
+      const app = storyResult.app || (div as any).__vue_app__;
       let _app: any;
       if (!app) {
         _app = Vue.createApp({


### PR DESCRIPTION
Fixes integration with speedy-links which rerenders in the SPA manner by calling `renderWith` on the same node with same params, but a different Vue component for each page.