### PR TITLE
feat(fast): rerender FAST template

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -26,8 +26,8 @@ export async function render(
     }
     case "ViewTemplate": {
       // FAST
-      storyResult.render({}, div);
-      return true;
+      const view = storyResult.render({}, div);
+      return () => view.dispose();
     }
     case "Hole": {
       // uhtml


### PR DESCRIPTION
`template.render` doesn't rerender, but setups the template and bindings from scratch and appends nodes resulting in duplicates when you try to rerender.

This PR solves it by disposing the previously created "view", which does the whole job of cleaning bindings and removing old nodes from DOM.